### PR TITLE
Use updated anonymous class for medialibrary migration

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -157,9 +157,9 @@ abstract class TestCase extends Orchestra
 
         TestModel::create(['name' => 'test']);
 
-        include_once 'vendor/spatie/laravel-medialibrary/database/migrations/create_media_table.php.stub';
+        $migration = include 'vendor/spatie/laravel-medialibrary/database/migrations/create_media_table.php.stub';
 
-        (new \CreateMediaTable())->up();
+        (new $migration)->up();
     }
 
     // FIXME what is this method for?


### PR DESCRIPTION
The tests are failing because of change in spatie's media library package, where they updated to the new anonymous classes for migrations. This PR updates the tests to work with the anonymous migration class.